### PR TITLE
18.10 compatibility tweak for blocktype/zotero

### DIFF
--- a/blocktype/zotero/lib.php
+++ b/blocktype/zotero/lib.php
@@ -100,7 +100,7 @@ class PluginBlocktypeZotero extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function get_instance_config_javascript() {
+    public static function get_instance_config_javascript(BlockInstance $instance) {
         return array('js/configform.js');
     }
 


### PR DESCRIPTION
get_instance_config_javascript() expects a BlockInstance instance to be passed in for 18.10+.